### PR TITLE
Perform unattended build and install

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,39 @@
+Arch Linux cross-toolchain for Raspberry Pi
+===========================================
+
+This project will compile GCC for ARMv7 to provide the ABI that is required for
+cross-compiling source code for Raspberry Pi and similar single board computers.
+
+Usage
+-----
+
+```
+$ git clone https://github.com/tavianator/arch-rpi-cross.git
+$ cd arch-rpi-cross/
+$ git submodule init
+$ git submodule update
+$ ./install.sh
+```
+
+The build is performed in multiple stages. After each stage is completed you
+will be prompted to install the resulting package. The script will then proceed
+automatically to the next stage.
+
+Passing options
+---------------
+
+If desired you can add options for `makepkg` when invoking the script:
+
+```
+$ ./install.sh -Csf
+```
+
+Unattended build
+----------------
+
+To do an unattended build for CI or automated build systems, pass the
+`--unattended` option. Any other options will be ignored.
+
+```
+$ ./install.sh --unattended
+```

--- a/install.sh
+++ b/install.sh
@@ -10,14 +10,18 @@ glibc_filename="glibc-2.31.tar.xz"
 args=("$@")
 
 function build() {
-    (
-        cd "./${prefix}-$1"
-        package_filename=$(makepkg --packagelist)
-        if [[ ! -f "$package_filename" ]] ; then
-          makepkg --clean --noconfirm "${args[@]}"
-        fi
-        sudo pacinstall --file "$package_filename" --resolve-conflicts=all --no-confirm
-    )
+    if [[ "$args" -eq "--unattended" ]]; then
+      (
+          cd "./${prefix}-$1"
+          package_filename=$(makepkg --packagelist)
+          if [[ ! -f "$package_filename" ]] ; then
+            makepkg --clean --noconfirm
+          fi
+          sudo pacinstall --file "$package_filename" --resolve-conflicts=all --no-confirm
+      )
+    else
+        (cd "./${prefix}-$1" && makepkg -i "${args[@]}")
+    fi
 }
 
 build binutils

--- a/install.sh
+++ b/install.sh
@@ -10,7 +10,14 @@ glibc_filename="glibc-2.31.tar.xz"
 args=("$@")
 
 function build() {
-    (cd "./${prefix}-$1" && makepkg -i "${args[@]}")
+    (
+        cd "./${prefix}-$1"
+        package_filename=$(makepkg --packagelist)
+        if [[ ! -f "$package_filename" ]] ; then
+          makepkg --clean --noconfirm "${args[@]}"
+        fi
+        sudo pacinstall --file "$package_filename" --resolve-conflicts=all --no-confirm
+    )
 }
 
 build binutils


### PR DESCRIPTION
Currently the installation requires manual intervention after every step: the user needs to confirm the installation of every individual package and needs to solve the conflicts. This makes it necessary to keep an eye on the installation procedure which is not ideal since it takes a long time.

This PR allows the entire installation to run unattended.